### PR TITLE
ci: add GitHub Actions workflow "Publish npm package function-types"

### DIFF
--- a/.github/workflows/lint-workflow.yaml
+++ b/.github/workflows/lint-workflow.yaml
@@ -1,0 +1,23 @@
+name: Lint GitHub Actions workflows
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up actionlint
+        id: setup_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+      - name: Lint
+        run: ${{ steps.setup_actionlint.outputs.executable }} -color

--- a/.github/workflows/publish-function-types.yaml
+++ b/.github/workflows/publish-function-types.yaml
@@ -1,0 +1,36 @@
+name: Publish npm package function-types
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version-file: packages/types/package.json
+          registry-url: https://registry.npmjs.org
+
+      - name: Update npm and corepack
+        run: |
+          npm i -g npm
+          npm i -g corepack@latest
+
+      - name: Publish
+        working-directory: packages/types
+        run: |
+          corepack enable
+          pnpm install
+          pnpm publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
This pull request adds new GitHub Actions workflows, `Publish npm package function-types` and `Lint GitHub Actions workflows`.

📓 For now, the workflow supports only `workflow_dispatch` to trigger it manually. However, it will soon be improved to automate the publishing of the package using release or tag.

