### PR TITLE
ci: remove step to upgrade npm and corepack from "Publish npm package function-types" workflow

### DIFF
--- a/.github/workflows/publish-function-types.yaml
+++ b/.github/workflows/publish-function-types.yaml
@@ -21,11 +21,6 @@ jobs:
           node-version-file: packages/types/package.json
           registry-url: https://registry.npmjs.org
 
-      - name: Update npm and corepack
-        run: |
-          npm i -g npm
-          npm i -g corepack@latest
-
       - name: Publish
         working-directory: packages/types
         run: |


### PR DESCRIPTION
This pull request removes step to upgrade npm and corepack from `Publish npm package function-types` workflow.