### PR TITLE
ci: fix "Publish npm package function-types" workflow

### DIFF
--- a/.github/workflows/publish-function-types.yaml
+++ b/.github/workflows/publish-function-types.yaml
@@ -18,12 +18,11 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version-file: packages/types/package.json
+          node-version: '22'
           registry-url: https://registry.npmjs.org
 
-      - name: Update npm and corepack
+      - name: Update corepack
         run: |
-          npm i -g npm
           npm i -g corepack@latest
 
       - name: Publish


### PR DESCRIPTION
- remove `npm i -g npm`
- specify `node-version`