### PR TITLE
ci: fix setup-node option in "Publish npm package function-kysely-tailordb" workflow

### DIFF
--- a/.github/workflows/publish-function-kysely-tailordb.yaml
+++ b/.github/workflows/publish-function-kysely-tailordb.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: packages/kysely-tailordb/package.json
+          node-version-file: packages/kysely-tailordb/package.json
           registry-url: https://registry.npmjs.org
 
       - name: Update corepack


### PR DESCRIPTION
This pull request fixes `setup-node` option in `Publish npm package function-kysely-tailordb` workflow.