### PR TITLE
chore: bump version of @tailor-platform/function-types to 0.2.0

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/function-types",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "TypeScript types for Tailor Platform Function service",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This pull request udpates the version of `@tailor-platform/function-types` to `0.2.0`.

Changes:
- https://github.com/tailor-platform/function/pull/15
