### PR TITLE
chore: bump version of @tailor-platform/function-kysely-tailordb to 0.1.2

### DIFF
--- a/packages/kysely-tailordb/package.json
+++ b/packages/kysely-tailordb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/function-kysely-tailordb",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "description": "Kysely dialect for TailorDB",
   "repository": {


### PR DESCRIPTION
This pull request bumps version of `@tailor-platform/function-kysely-tailordb` to `0.1.2`.