### PR TITLE
fix: reduce bundle size of function script

### DIFF
--- a/packages/kysely-tailordb-codegen/build.js
+++ b/packages/kysely-tailordb-codegen/build.js
@@ -61,15 +61,14 @@ const getInjectContent = (globalName, globalInject) => {
   return `import { ${exportName} } from "${moduleSpecifier}"; globalThis.${globalName} = ${exportName};`;
 };
 
-// Due to the use of dynamic require, bundling `git-diff` is difficult.
-// However, since it's not used in this use case, we can mock it instead.
-const mockGitDiff = {
-  name: "mock-git-diff",
+// Mock packages that are difficult to bundle and not used in the current use case.
+const mockPackages = {
+  name: "mock-packages",
   setup(build) {
-    build.onResolve({ filter: /^git-diff$/ }, (args) => {
-      return { path: args.path, namespace: "git-diff" };
+    build.onResolve({ filter: /^(git-diff|cosmiconfig)$/ }, (args) => {
+      return { path: args.path, namespace: "mock-packages" };
     });
-    build.onLoad({ filter: /.*/, namespace: "git-diff" }, () => {
+    build.onLoad({ filter: /.*/, namespace: "mock-packages" }, () => {
       return { contents: "export default null" };
     });
   },
@@ -84,7 +83,7 @@ build({
   define: {
     global: "globalThis",
   },
-  plugins: [unenvAlias, unenvInject, mockGitDiff],
+  plugins: [unenvAlias, unenvInject, mockPackages],
   // Unused drivers are left unbundled as-is.
   // Note that future updates to `kysely-codegen` may introduce new drivers.
   external: [

--- a/packages/kysely-tailordb-codegen/package.json
+++ b/packages/kysely-tailordb-codegen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/function-kysely-tailordb-codegen",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Generate Kysely code for TailorDB",
   "repository": {
     "type": "git",


### PR DESCRIPTION
In `kysely-codegen@0.18`, support for config files via `cosmiconfig` was introduced.
https://github.com/RobinBlomberg/kysely-codegen#configuration-file

However, `cosmiconfig` uses dynamic imports to load `typescript` (likely to support `.ts` config files), which causes `typescript` to be included in the bundle. This significantly increases the bundle size.

Since the config file feature is not used in this use case, we’ve mocked `cosmiconfig`, similar to how `git-diff` was handled.
This avoids the bundling issue and ensures the script stays within the Tailor Platform's size limits.

As a result, the bundle size was reduced from 4.1MB to 657KB.