### PR TITLE
feat: add function logger utility

### DIFF
--- a/.github/workflows/publish-function-logger.yaml
+++ b/.github/workflows/publish-function-logger.yaml
@@ -1,0 +1,36 @@
+name: Publish npm package function-logger
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          registry-url: https://registry.npmjs.org
+
+      - name: Update corepack
+        run: |
+          npm i -g corepack@latest
+
+      - name: Publish
+        working-directory: packages/logger
+        run: |
+          corepack enable
+          pnpm install
+          pnpm run build
+          pnpm publish --no-git-checks --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,0 +1,38 @@
+# @tailor-platform/function-logger
+
+Simple logger utility for Tailor Function applications.
+
+## Installation
+
+```bash
+npm install @tailor-platform/function-logger
+```
+
+## Usage
+
+```typescript
+import logger from '@tailor-platform/function-logger';
+
+// Log messages at different levels
+logger.debug('Debug message', { extra: 'data' });
+logger.info('Info message');
+logger.warn('Warning message');
+logger.error('Error message', new Error('Something went wrong'));
+```
+
+## API
+
+The logger provides four log levels:
+
+- `debug`: For detailed debugging information
+- `info`: For general informational messages
+- `warn`: For warning messages
+- `error`: For error messages
+
+Each method accepts a message string and optional additional arguments that will be logged.
+
+## Building
+
+```bash
+npm run build
+```

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tailor-platform/function-logger",
+  "version": "1.0.0",
+  "description": "Simple logger utility for Tailor applications",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tailor-platform/function",
+    "directory": "packages/logger"
+  },
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/function-logger",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "description": "Simple logger utility for Tailor applications",
   "repository": {
     "type": "git",

--- a/packages/logger/pnpm-lock.yaml
+++ b/packages/logger/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
+packages:
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.8.3: {}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,35 @@
+export enum LogLevel {
+  DEBUG = 'debug',
+  INFO = 'info',
+  WARN = 'warn',
+  ERROR = 'error',
+}
+
+export interface Logger {
+  debug: (message: string, ...args: unknown[]) => void;
+  info: (message: string, ...args: unknown[]) => void;
+  warn: (message: string, ...args: unknown[]) => void;
+  error: (message: string, ...args: unknown[]) => void;
+}
+
+const createConsoleLogger = (): Logger => ({
+  debug: (message: string, ...args: unknown[]): void => {
+    console.log(`[DEBUG] ${message}`, ...args);
+  },
+
+  info: (message: string, ...args: unknown[]): void => {
+    console.log(`[INFO] ${message}`, ...args);
+  },
+
+  warn: (message: string, ...args: unknown[]): void => {
+    console.warn(`[WARN] ${message}`, ...args);
+  },
+
+  error: (message: string, ...args: unknown[]): void => {
+    console.error(`[ERROR] ${message}`, ...args);
+  },
+});
+
+export const logger: Logger = createConsoleLogger();
+
+export default logger;

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Taken from the shopify-app project.

https://github.com/tailor-platform/shopify-app/blob/main/apps/shopify-backend/utils/logger.ts

This scaffolds potential logger tooling for use in function service.

This encourages robust logging without using console.log directly.