### PR TITLE
fix(logger): add main and exports

### DIFF
--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/function-logger",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Simple logger utility for Tailor applications",
   "repository": {
     "type": "git",
@@ -8,8 +8,15 @@
     "directory": "packages/logger"
   },
   "module": "dist/index.js",
+  "main": "./dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "clean": "rm -rf dist"


### PR DESCRIPTION
## Problem

ESM export was not properly setup.
```
Error: Failed to resolve entry for package "@tailor-platform/function-logger". The package may have incorrect main/module/exports specified in its package.json.
```


## Description

This pull request updates the package configuration for the `@tailor-platform/function-logger` package to improve compatibility and module resolution. The most important changes are grouped below:

Versioning and metadata updates:
* Bumped the package version from `0.1.0` to `0.1.1` to reflect these changes.

Module resolution and exports improvements:
* Added the `main` field pointing to `./dist/index.js` to clarify the entry point for CommonJS consumers.
* Introduced the `exports` field to explicitly define entry points for both types and default exports, improving compatibility with modern bundlers and Node.js module resolution.