### PR TITLE
fix return type

### DIFF
--- a/packages/types/tailor.d.ts
+++ b/packages/types/tailor.d.ts
@@ -77,8 +77,8 @@ declare namespace tailor.iconv {
    */
   function decode<T extends string>(
     buffer: Uint8Array | ArrayBuffer,
-    encoding: T
-  ): T extends 'UTF8' | 'UTF-8' ? string : Uint8Array;
+    encoding: string
+  ): string;
 
   /**
    * Encode string to buffer


### PR DESCRIPTION
tailor.iconv.decode always returns a string type