### PR TITLE
ci: use trusted publishing for npm packages

### DIFF
--- a/.github/workflows/publish-function-kysely-tailordb-codegen.yaml
+++ b/.github/workflows/publish-function-kysely-tailordb-codegen.yaml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 defaults:
   run:
@@ -21,8 +22,9 @@ jobs:
           node-version-file: packages/kysely-tailordb-codegen/package.json
           registry-url: https://registry.npmjs.org
 
-      - name: Update corepack
+      - name: Update npm and corepack
         run: |
+          npm i -g npm@latest
           npm i -g corepack@latest
 
       - name: Publish
@@ -32,5 +34,3 @@ jobs:
           pnpm install
           pnpm run build
           pnpm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-function-kysely-tailordb.yaml
+++ b/.github/workflows/publish-function-kysely-tailordb.yaml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 defaults:
   run:
@@ -21,8 +22,9 @@ jobs:
           node-version-file: packages/kysely-tailordb/package.json
           registry-url: https://registry.npmjs.org
 
-      - name: Update corepack
+      - name: Update npm and corepack
         run: |
+          npm i -g npm@latest
           npm i -g corepack@latest
 
       - name: Publish
@@ -32,5 +34,3 @@ jobs:
           pnpm install
           pnpm run build
           pnpm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-function-logger.yaml
+++ b/.github/workflows/publish-function-logger.yaml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 defaults:
   run:
@@ -21,8 +22,9 @@ jobs:
           node-version: '22'
           registry-url: https://registry.npmjs.org
 
-      - name: Update corepack
+      - name: Update npm and corepack
         run: |
+          npm i -g npm@latest
           npm i -g corepack@latest
 
       - name: Publish
@@ -32,5 +34,3 @@ jobs:
           pnpm install
           pnpm run build
           pnpm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/publish-function-types.yaml
+++ b/.github/workflows/publish-function-types.yaml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 defaults:
   run:
@@ -21,8 +22,9 @@ jobs:
           node-version: '22'
           registry-url: https://registry.npmjs.org
 
-      - name: Update corepack
+      - name: Update npm and corepack
         run: |
+          npm i -g npm@latest
           npm i -g corepack@latest
 
       - name: Publish
@@ -31,5 +33,3 @@ jobs:
           corepack enable
           pnpm install
           pnpm publish --no-git-checks --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}


### PR DESCRIPTION
## WHAT

This pull request updates GitHub Actions workflows to publish npm packages to use trusted publishing instead of token.

## WHY

- https://docs.npmjs.com/trusted-publishers
- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
