### PR TITLE
feat: Add TailorDB file API type definitions

### DIFF
--- a/packages/types/tailor.d.ts
+++ b/packages/types/tailor.d.ts
@@ -184,8 +184,7 @@ interface FileDownloadResponse {
 type StreamValue =
   | { type: 'metadata'; metadata: StreamMetadata }
   | { type: 'chunk'; data: Uint8Array; position: number }
-  | { type: 'complete' }
-  | { type: 'error'; error: string };
+  | { type: 'complete' };
 
 /**
  * Stream iterator interface


### PR DESCRIPTION
### Summary

Add type definitions for the TailorDB file API. These types enable type-safe usage of file operations within TailorDB.

### Changes

Added TailorDBFileAPI interface with the following methods:
• upload
• download
• delete
• getMetadata
• openDownloadStream
• Introduced supporting types:
• FileMetadata, UploadMetadata, DownloadMetadata, StreamMetadata
• FileUploadResponse, FileDownloadResponse, FileStreamIterator, StreamValue
• Added TailorDBFileError for consistent error handling
