### PR TITLE
chore: bump version to 0.6.0 after adding new type definitions

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tailor-platform/function-types",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "TypeScript types for Tailor Platform Function service",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This version update reflects the changes introduced in https://github.com/tailor-platform/function/pull/92, where new type definitions for TailorDB File API were added.