### PR TITLE
feat(types): add tailor.context.getInvoker types

### DIFF
--- a/.changeset/add-context-get-invoker.md
+++ b/.changeset/add-context-get-invoker.md
@@ -1,0 +1,5 @@
+---
+"@tailor-platform/function-types": patch
+---
+
+Add `tailor.context` namespace with `getInvoker()` for retrieving information about the invoker of the current function execution

--- a/packages/types/tailor.d.ts
+++ b/packages/types/tailor.d.ts
@@ -496,3 +496,27 @@ declare namespace tailor.workflow {
         callback: (waitPayload: any) => any
     ): Promise<void>;
 }
+
+declare namespace tailor.context {
+    /**
+     * Information about the invoker of the current function execution.
+     */
+    interface Invoker {
+        /** The invoker's ID */
+        id: string;
+        /** The invoker's type */
+        type: "user" | "machine_user";
+        /** The workspace ID */
+        workspaceId: string;
+        /** The invoker's attribute IDs */
+        attributes: string[];
+        /** The invoker's attribute map */
+        attributeMap: Record<string, unknown>;
+    }
+
+    /**
+     * Returns information about the invoker of the current function execution,
+     * or `null` for anonymous invocations.
+     */
+    function getInvoker(): Invoker | null;
+}


### PR DESCRIPTION
## Summary

- Add `tailor.context` namespace with `Invoker` interface and `getInvoker()` function
- `getInvoker()` returns `null` for anonymous invocations