### PR TITLE
ci: bump Node to 24 to fix release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,8 @@ jobs:
           node-version-file: ./package.json
           registry-url: https://registry.npmjs.org
       
-      - name: Update npm and setup pnpm
+      - name: Setup pnpm
         run: |
-          npm i -g npm@latest
           npm i -g corepack@latest
           corepack enable
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   },
   "packageManager": "pnpm@10.33.0",
   "engines": {
-    "node": "22.x"
+    "node": "24.x"
   }
 }


### PR DESCRIPTION
## Summary

- Bump `engines.node` from `22.x` to `24.x`
- Drop `npm i -g npm@latest` from the publish workflow (no longer needed)

## Why

The Publish npm packages workflow has been failing since #160 (April 6) with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

Root cause is a known regression in the Node 22.22.2 toolcache image: the bundled npm 10.9.7 has a broken dependency tree (missing `promise-retry`), so any command that triggers `@npmcli/arborist` — including `npm i -g npm@latest` — fails immediately.

Node 24 (current Active LTS) ships npm 11.x which already supports trusted publishing (OIDC), so the global npm upgrade step becomes unnecessary.

Refs:
- actions/runner-images#13883
- nodejs/node#62425