### PR TITLE
fix(types): remove non-existent updatedAt from tailor.idp.User

### DIFF
--- a/.changeset/remove-user-updated-at.md
+++ b/.changeset/remove-user-updated-at.md
@@ -1,0 +1,5 @@
+---
+"@tailor-platform/function-types": patch
+---
+
+Remove non-existent `updatedAt` field from `tailor.idp.User`

--- a/packages/types/tailor.d.ts
+++ b/packages/types/tailor.d.ts
@@ -332,7 +332,6 @@ declare namespace tailor.idp {
     name: string;
     disabled: boolean;
     createdAt?: string;
-    updatedAt?: string;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Remove `updatedAt?: string` from `tailor.idp.User` because the IDP service does not return this field
- The declaration was misleading consumers into expecting an optional timestamp that was always `undefined`