### PR TITLE
feat: add tailor.aigateway.get types for AI Gateway URL resolution

### DIFF
--- a/.changeset/tailor-aigateway-get.md
+++ b/.changeset/tailor-aigateway-get.md
@@ -1,0 +1,5 @@
+---
+"@tailor-platform/function-types": minor
+---
+
+Add `tailor.aigateway.get(name)` types for resolving an AI Gateway URL in the caller's workspace.

--- a/packages/types/tailor.d.ts
+++ b/packages/types/tailor.d.ts
@@ -61,6 +61,27 @@ declare namespace tailor.authconnection {
   function getConnectionToken(connectionName: string): Promise<any>;
 }
 
+declare namespace tailor.aigateway {
+  /**
+   * AIGateway describes a resolved AI Gateway in the caller's workspace.
+   */
+  interface AIGateway {
+    /**
+     * Base URL of the AI Gateway, e.g.
+     * `https://my-aigateway-<workspace_hash>.ai.erp.dev`. Requests to this URL
+     * are automatically authenticated for the calling workspace.
+     */
+    url: string;
+  }
+
+  /**
+   * get resolves a named AI Gateway in the caller's own workspace and returns
+   * it. The gateway's existence is verified at call time, so resolving a name
+   * that does not exist rejects rather than failing later inside `fetch`.
+   */
+  function get(name: string): Promise<AIGateway>;
+}
+
 declare namespace tailor.iconv {
   /**
    * Convert string from one encoding to another


### PR DESCRIPTION
## Summary

Adds type declarations for the `tailor.aigateway.get(name)` built-in, which resolves a named AI Gateway in the function's own workspace and returns its URL (verified to exist at call time).

```ts
declare namespace tailor.aigateway {
  interface AIGateway {
    url: string;
  }
  function get(name: string): Promise<AIGateway>;
}
```

Usage:

```js
const gw = await tailor.aigateway.get("my-aigateway");
const res = await fetch(`${gw.url}/v1/chat/completions`, { method: "POST", /* ... */ });
```

The return value is an `AIGateway` object (not a bare string) so future fields can be added without breaking callers. Mirrors the `tailor.<namespace>.<method>` shape used by `tailor.secretmanager` / `tailor.idp`.

A changeset is included (`minor` bump for `@tailor-platform/function-types`).