### PR TITLE
fix(logger): use correct console methods for debug and info levels

### DIFF
--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -14,11 +14,11 @@ export interface Logger {
 
 const createConsoleLogger = (): Logger => ({
   debug: (message: string, ...args: unknown[]): void => {
-    console.log(`[DEBUG] ${message}`, ...args);
+    console.debug(`[DEBUG] ${message}`, ...args);
   },
 
   info: (message: string, ...args: unknown[]): void => {
-    console.log(`[INFO] ${message}`, ...args);
+    console.info(`[INFO] ${message}`, ...args);
   },
 
   warn: (message: string, ...args: unknown[]): void => {


### PR DESCRIPTION
## Summary
- Fix `debug` and `info` log levels to use `console.debug` and `console.info` respectively, instead of both using `console.log`